### PR TITLE
ci(dependabot): changed 'target-branch'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: development
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Target branch is changed to development so that we avoid version bump on every change